### PR TITLE
Cli questions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 osu_*
 mpi-*
 test_*
+param_dict.json
 *.tar*
 *java*
 application.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 lint: ## Run linter
-	tox -e lint
+    tox -e lint
 clean: ## Remove .tox and build dirs
 	rm -rf .tox/
 	rm -rf venv/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-GETS
 lint: ## Run linter
 	tox -e lint
 clean: ## Remove .tox and build dirs

--- a/helloworld.py
+++ b/helloworld.py
@@ -1,0 +1,3 @@
+print('hello world from application.py')
+
+print('{} executed successfully'.format("['Jobbergate-Hello-World']"))

--- a/jobbergate_cli/appform.py
+++ b/jobbergate_cli/appform.py
@@ -1,0 +1,200 @@
+"""
+Appform
+=======
+
+Abstraction layer for questions. Each classe represents different question
+types, and QuestionBase"""
+
+from collections import deque
+from functools import partial, wraps
+
+
+questions = deque()
+workflows = {}
+
+
+class QuestionBase:
+    """Baseclass for questions.
+    All questions have variablename, message and an optional default.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Default value
+    """
+
+    def __init__(self, variablename, message, default):
+        self.variablename = variablename
+        self.message = message
+        self.default = default
+
+
+class Text(QuestionBase):
+    """Asks for a text value.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Default value
+    """
+
+    def __init__(self, variablename, message, default=None):
+        super().__init__(variablename, message, default)
+
+
+class Integer(QuestionBase):
+    """Asks for an integer value. Could have min and/or max constrains.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param minval: Minumum value
+    :param maxval: Maximum value
+    :param default: Default value
+    """
+
+    def __init__(self, variablename, message, minval=None, maxval=None, default=None):
+        super().__init__(variablename, message, default)
+        self.maxval = maxval
+        self.minval = minval
+
+    def validate(self, _, value):
+        if self.minval is not None and self.maxval is not None:
+            return self.minval <= int(value) <= self.maxval
+        if self.minval is not None:
+            return self.minval <= int(value)
+        if self.maxval is not None:
+            return int(value) <= self.maxval
+        return True
+
+
+class List(QuestionBase):
+    """Gives the user a list to choose one from.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param choices: List with choices
+    :param default: Default value"""
+
+    def __init__(self, variablename, message, choices, default=None):
+        super().__init__(variablename, message, default)
+        self.choices = choices
+
+
+class Directory(QuestionBase):
+    """Asks for a directory name. If `exists` is `True` it checks if path exists and is a directory.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Default value
+    :param exists: Checks if given directory exists"""
+
+    def __init__(self, variablename, message, default=None, exists=None):
+        super().__init__(variablename, message, default)
+        self.exists = exists
+
+
+class File(QuestionBase):
+    """Asks for a file name. If `exists` is `True` it checks if path exists and is a directory.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Default value
+    :param exists: Checks if given file exists"""
+
+    def __init__(self, variablename, message, default=None, exists=None):
+        super().__init__(variablename, message, default)
+        self.exists = exists
+
+
+class Checkbox(QuestionBase):
+    """Gives the user a list to choose multiple entries from.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param choices: List with choices
+    :param default: Default value(s)"""
+
+    def __init__(self, variablename, message, choices, default=None):
+        super().__init__(variablename, message, default)
+        self.choices = choices
+
+
+class Confirm(QuestionBase):
+    """Asks a question with an boolean answer (true/false).
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Default value
+    """
+
+    def __init__(self, variablename, message, default=None):
+        super().__init__(variablename, message, default)
+
+
+class BooleanList(QuestionBase):
+    """Gives the use a boolean question, and depending on answer it shows `whentrue` or `whenfalse` questions.
+    `whentrue` and `whenfalse` are lists with questions. Could contain multiple levels of BooleanLists.
+
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Default value
+    :param whentrue: List of questions to show if user answers yes/true on this question
+    :param whentrue: List of questions to show if user answers no/false on this question
+    """
+
+    def __init__(
+        self, variablename, message, default=None, whentrue=None, whenfalse=None
+    ):
+        super().__init__(variablename, message, default)
+        if whentrue is None and whenfalse is None:
+            raise ValueError("Empty questions lists")
+        self.whentrue = whentrue
+        self.whenfalse = whenfalse
+        self.ignore = lambda a: a[self.variablename]
+        self.noignore = lambda a: not a[self.variablename]
+
+
+class Const(QuestionBase):
+    """Sets the variable to the `default` value. Doesn't show anything.
+
+    :param variablename: The variable name to set
+    :param message: Message to show
+    :param default: Value that variable is set to
+    """
+
+    def __init__(self, variablename, default):
+        super().__init__(variablename, None, default)
+
+
+def workflow(func=None, *, name=None):
+    """A decorator for workflows. Adds an workflow question and all questions
+    added in the decorated question is asked after selecting workflow.
+
+    :param name: (optional) Descriptional name that is shown when choosing workflow
+
+    Add a workflow named debug:
+
+    .. code-block:: python
+
+        @workflow
+        def debug(data):
+            return [appform.File("debugfile", "Name of debug file")]
+
+    Add a workflow with longer name:
+
+    .. code-block:: python
+
+        @workflow(name="Secondary Eigen step")
+        def 2ndstep(data):
+            return [appform.Text("eigendata", "Definition of eigendata")]
+    """
+
+    if func is None:
+        return partial(workflow, name=name)
+
+    @wraps(func)
+    def wrapper(*args, **kvargs):
+        return func(*args, **kvargs)
+
+    workflows[name or func.__name__] = func
+
+    return wrapper

--- a/jobbergate_cli/application_base.py
+++ b/jobbergate_cli/application_base.py
@@ -2,7 +2,7 @@ import yaml
 
 class JobbergateApplicationBase:
     def __init__(self):
-        jobbergate_yaml = yaml.load("jobbergate.yaml")
+        jobbergate_yaml = yaml.load("/tmp/jobbergate.yaml")
         self._questions = list()
         self.jobbergate_config = jobbergate_yaml['jobbergate-config']
         self.application_config = jobbergate_yaml['application-config']

--- a/jobbergate_cli/application_base.py
+++ b/jobbergate_cli/application_base.py
@@ -1,0 +1,14 @@
+import yaml
+
+class JobbergateApplicationBase:
+    def __init__(self):
+        jobbergate_yaml = yaml.load("jobbergate.yaml")
+        self._questions = list()
+        self.jobbergate_config = jobbergate_yaml['jobbergate-config']
+        self.application_config = jobbergate_yaml['application-config']
+
+    def mainflow(self):
+        raise Exception("Inheriting class must override this method.")
+
+    def render(self):
+        raise Exception("Inheriting class must override this method.")

--- a/jobbergate_cli/application_base.py
+++ b/jobbergate_cli/application_base.py
@@ -1,11 +1,13 @@
 import yaml
 
-class JobbergateApplicationBase:
+class JobbergateApplicationBase(object):
     def __init__(self):
-        jobbergate_yaml = yaml.load("/tmp/jobbergate.yaml")
+        jobbergate_yaml_file = open("/tmp/jobbergate.yaml")
+        jobbergate_yaml = yaml.load(jobbergate_yaml_file, Loader=yaml.FullLoader)
+        # print(len(jobbergate_yaml))
         self._questions = list()
-        self.jobbergate_config = jobbergate_yaml['jobbergate-config']
-        self.application_config = jobbergate_yaml['application-config']
+        self.jobbergate_config = jobbergate_yaml['jobbergate_config']
+        self.application_config = jobbergate_yaml['application_config']
 
     def mainflow(self):
         raise Exception("Inheriting class must override this method.")

--- a/jobbergate_cli/jobberappslib.py
+++ b/jobbergate_cli/jobberappslib.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+def get_output_file():
+    """Returns the output file name, extracted from the command line.
+    """
+    # TODO cleanup?
+    scriptout="?"
+    ind = 2
+    while ind < len(sys.argv):
+        if sys.argv[ind] in ["-f", "--fast"]:
+            ind = ind+1
+        elif sys.argv[ind] in ["-a", "--answerfile", "-p", "--prefill", "-s", "--saveanswers", "-t", "--template"]:
+            ind = ind+2
+        else:
+            scriptout=sys.argv[ind]
+            break
+    return scriptout
+
+def get_running_jobs(user_only = True):
+    """Returns a list of the user's currently running jobs, as given by SLURM.
+    """
+    cmd_args = ['squeue', '--format="%.8A %j"', '--noheader'] # format:[job ID, 8 chars] [job name]
+    if user_only:
+        cmd_args.append('--user='+os.getenv('USER'))
+    try:
+        cmd_results = subprocess.run(cmd_args, stdout=subprocess.PIPE)
+        # Skip last line (empty), strip quotation marks
+        ID_alternatives = cmd_results.stdout.decode().split("\n")[:-1]
+        ID_alternatives = [j.strip('"') for j in ID_alternatives]
+    except:
+        print("Could not retrieve queue information from SLURM.")
+        return []
+    return ID_alternatives
+
+def get_file_list(path=None, search_term = "*.*"):
+    """ Returns a list of inputfiles in a directory ( default: pwd) """
+    if not path:
+        path = Path.cwd()
+
+    files = sorted(path.glob(search_term), key=os.path.getmtime, reverse=True)
+
+    files = [x.name for x in files if x.is_file()]
+
+    return files

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -368,7 +368,8 @@ class JobbergateApi:
             method="GET",
             endpoint=f"{self.api_endpoint}/application/"
         )
-        response = [{k: v for k, v in d.items() if k not in ['application_config', 'application_file']} for d in response]
+        suppress = ['application_config', 'application_file', 'created_at', 'updated_at', 'application_dir_listing', 'application_location', 'application_dir_listing_acquired']
+        response = [{k: v for k, v in d.items() if k not in suppress} for d in response]
         return response
 
     @tabulate_decorator

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -29,6 +29,17 @@ class JobbergateApi:
         self.application_config = application_config
         self.api_endpoint = api_endpoint
         self.user_id = user_id
+        # Suppress from list- and create- application:
+        self.application_suppress = [
+            'application_config',
+            'application_file',
+            'created_at',
+            'updated_at',
+            'application_dir_listing',
+            'application_location',
+            'application_dir_listing_acquired'
+        ]
+
 
     def tardir(self, path, tar_name):
         archive = tarfile.open(tar_name, "w|gz")
@@ -372,8 +383,7 @@ class JobbergateApi:
             method="GET",
             endpoint=f"{self.api_endpoint}/application/"
         )
-        suppress = ['application_config', 'application_file', 'created_at', 'updated_at', 'application_dir_listing', 'application_location', 'application_dir_listing_acquired']
-        response = [{k: v for k, v in d.items() if k not in suppress} for d in response]
+        response = [{k: v for k, v in d.items() if k not in self.application_suppress} for d in response]
         return response
 
     @tabulate_decorator
@@ -401,7 +411,9 @@ class JobbergateApi:
             data=data,
             files=files
         )
-        # del response['application_file']
+
+        response = [{k: v for k, v in d.items() if k not in self.application_suppress} for d in response]
+        os.remove(tar_name)
         return response
 
     @tabulate_decorator

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -137,6 +137,7 @@ class JobbergateApi:
                 files=files
             )
 
+            print(type(response['job_script_data_as_string']))
             rendered_dict = json.loads(response['job_script_data_as_string'])
 
             job_script_data_as_string = ""

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -152,10 +152,11 @@ class JobbergateApi:
                 endpoint=f"{self.api_endpoint}/application/{application_id}"
             )
 
-            # param_dict = {
-            #     "jobbergate_config": {},
-            #     "application_config":{}
-            #               }
+            param_dict = {
+                "jobbergate_config": {},
+                "application_config":{}
+                          }
+            questions = []
             # questions = []
             # for key, value in config.items():
             #     for key2, value2 in value.items():
@@ -178,9 +179,9 @@ class JobbergateApi:
 
             # CONFIG_PATH.write_text(app_data['application_config'])
             # application_config.write(app_data['application_file'])
-            # application_config = open(CONFIG_PATH, "w")
-            # w = application_config.write(app_data['application_config'])
-            # application_config.close()
+            application_config = open(CONFIG_PATH, "w")
+            w = application_config.write(app_data['application_config'])
+            application_config.close()
 
             jobbergate_yaml_file = open(CONFIG_PATH)
             jobbergate_yaml = yaml.load(jobbergate_yaml_file, Loader=yaml.FullLoader)
@@ -189,7 +190,6 @@ class JobbergateApi:
             # print(a.application_config)
             # print(a.jobbergate_config)
             # print(a._questions)
-            questions = []
             for i in range(len(application._questions)):
                 if hasattr(application._questions[i], "choices"):
                     question = inquirer.List(
@@ -202,12 +202,29 @@ class JobbergateApi:
                         message=application._questions[i].message,)
                 questions.append(question)
 
-            print(questions)
             answers = inquirer.prompt(questions)
-            param_dict = {
-                "jobbergate_config": {},
-                "application_config":{}
-                          }
+            print(answers)
+            print(type(jobbergate_yaml['jobbergate_config']))
+            jobbergate_yaml['jobbergate_config'].update(answers)
+            print(jobbergate_yaml['jobbergate_config'])
+            #test running questions in shared() - also why is it called 'shared'?
+            shared_questions = application.shared(data=jobbergate_yaml['jobbergate_config'])
+            print(shared_questions)
+            #awful name - pick a new one
+            questions_2 = []
+            for i in range(len(shared_questions)):
+                if hasattr(shared_questions[i], "choices"):
+                    question = inquirer.List(
+                                    name=shared_questions[i].variablename,
+                                    message=shared_questions[i].message,
+                                    choices=shared_questions[i].choices,)
+                else:
+                    question = inquirer.Text(
+                        name=shared_questions[i].variablename,
+                        message=shared_questions[i].message,)
+                questions_2.append(question)
+            test_answers = inquirer.prompt(questions_2)
+            print(test_answers)
             for key, value in jobbergate_yaml.items():
                 for key2, value2 in value.items():
                     param_dict[key][key2] = answers[key2]
@@ -219,7 +236,6 @@ class JobbergateApi:
             #TODO: Put below in function after testing - DRY
             files = {'upload_file': open(param_filename, 'rb')}
             print(param_dict)
-            print(var_does_not_exist)
 
             response = self.jobbergate_request(
                 method="POST",

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -71,7 +71,7 @@ class JobbergateApi:
                     files=files,
                     headers={'Authorization': 'JWT ' + self.token},
                     verify=False)
-                print(response)
+                print(response.content)
         return response
 
     def jobbergate_run(self, application_name, *argv):

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -56,12 +56,22 @@ class JobbergateApi:
                 headers={'Authorization': 'JWT ' + self.token},
                 verify=False).text
         if method == "POST":
-            response = requests.post(
-                endpoint,
-                data=data,
-                files=files,
-                headers={'Authorization': 'JWT ' + self.token},
-                verify=False).json()
+            try:
+                response = requests.post(
+                    endpoint,
+                    data=data,
+                    files=files,
+                    headers={'Authorization': 'JWT ' + self.token},
+                    verify=False).json()
+            except Exception as e:
+                print(e)
+                response = requests.post(
+                    endpoint,
+                    data=data,
+                    files=files,
+                    headers={'Authorization': 'JWT ' + self.token},
+                    verify=False)
+                print(response)
         return response
 
     def jobbergate_run(self, application_name, *argv):

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -147,7 +147,6 @@ class JobbergateApi:
             response['job_script_data_as_string'] = job_script_data_as_string
 
         else:
-            print("no param file - testing questions")
             app_data = self.jobbergate_request(
                 method="GET",
                 endpoint=f"{self.api_endpoint}/application/{application_id}"

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -186,10 +186,13 @@ class JobbergateApi:
             jobbergate_yaml_file = open(CONFIG_PATH)
             jobbergate_yaml = yaml.load(jobbergate_yaml_file, Loader=yaml.FullLoader)
             module = self.import_questions_into_jobbergate_cli(module_path=MODULE_PATH)
-            print(dir(module.JobbergateApplication(jobbergate_yaml)))
+            a = module.JobbergateApplication(jobbergate_yaml)
+            print(a.application_config)
+            print(a.jobbergate_config)
+            print(a._questions)
             print(var_does_not_exist)
+            a.mainflow()
             questions = []
-            config = yaml.safe_load(app_data['application_config'])
             for i in range(len(self._questions)):
                 if hasattr(self._questions[i], "choices"):
                     question = inquirer.List(
@@ -208,8 +211,7 @@ class JobbergateApi:
                 "jobbergate_config": {},
                 "application_config":{}
                           }
-            print(config)
-            for key, value in config.items():
+            for key, value in jobbergate_yaml.items():
                 for key2, value2 in value.items():
                     param_dict[key][key2] = answers[key2]
             param_filename = '/tmp/param_dict.json'

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -29,7 +29,6 @@ class JobbergateApi:
         self.application_config = application_config
         self.api_endpoint = api_endpoint
         self.user_id = user_id
-        self._questions = []
 
     def tardir(self, path, tar_name):
         archive = tarfile.open(tar_name, "w|gz")
@@ -186,23 +185,21 @@ class JobbergateApi:
             jobbergate_yaml_file = open(CONFIG_PATH)
             jobbergate_yaml = yaml.load(jobbergate_yaml_file, Loader=yaml.FullLoader)
             module = self.import_questions_into_jobbergate_cli(module_path=MODULE_PATH)
-            a = module.JobbergateApplication(jobbergate_yaml)
-            print(a.application_config)
-            print(a.jobbergate_config)
-            print(a._questions)
-            print(var_does_not_exist)
-            a.mainflow()
+            application = module.JobbergateApplication(jobbergate_yaml)
+            # print(a.application_config)
+            # print(a.jobbergate_config)
+            # print(a._questions)
             questions = []
-            for i in range(len(self._questions)):
-                if hasattr(self._questions[i], "choices"):
+            for i in range(len(application._questions)):
+                if hasattr(application._questions[i], "choices"):
                     question = inquirer.List(
-                                    name=self._questions[i].variablename,
-                                    message=self._questions[i].message,
-                                    choices=self._questions[i].choices,)
+                                    name=application._questions[i].variablename,
+                                    message=application._questions[i].message,
+                                    choices=application._questions[i].choices,)
                 else:
                     question = inquirer.Text(
-                        name=self._questions[i].variablename,
-                        message=self._questions[i].message,)
+                        name=application._questions[i].variablename,
+                        message=application._questions[i].message,)
                 questions.append(question)
 
             print(questions)

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -188,28 +188,29 @@ class JobbergateApi:
             param_dict['jobbergate_config'].update(answers)
 
             #test running questions in shared() - also why is it called 'shared'?
-            shared_questions = application.shared(data=param_dict['jobbergate_config'])
-            # questions_2 awful name - pick a new one
-            questions_2 = []
-            for i in range(len(shared_questions)):
-                if shared_questions[i].default:
-                    print(shared_questions[i].variablename)
-                    question = inquirer.Text(
-                        name=shared_questions[i].variablename,
-                        message=shared_questions[i].message,
-                        default=shared_questions[i].default)
-                elif shared_questions[i].__class__.__name__ == 'List':
-                    question = inquirer.List(
-                                    name=shared_questions[i].variablename,
-                                    message=shared_questions[i].message,
-                                    choices=shared_questions[i].choices,)
-                else:
-                    question = inquirer.Text(
-                        name=shared_questions[i].variablename,
-                        message=shared_questions[i].message,)
-                questions_2.append(question)
-            test_answers = inquirer.prompt(questions_2)
-            param_dict['jobbergate_config'].update(test_answers)
+            if hasattr(application, "shared"):
+                shared_questions = application.shared(data=param_dict['jobbergate_config'])
+                # questions_2 awful name - pick a new one
+                questions_2 = []
+                for i in range(len(shared_questions)):
+                    if shared_questions[i].default:
+                        print(shared_questions[i].variablename)
+                        question = inquirer.Text(
+                            name=shared_questions[i].variablename,
+                            message=shared_questions[i].message,
+                            default=shared_questions[i].default)
+                    elif shared_questions[i].__class__.__name__ == 'List':
+                        question = inquirer.List(
+                                        name=shared_questions[i].variablename,
+                                        message=shared_questions[i].message,
+                                        choices=shared_questions[i].choices,)
+                    else:
+                        question = inquirer.Text(
+                            name=shared_questions[i].variablename,
+                            message=shared_questions[i].message,)
+                    questions_2.append(question)
+                    test_answers = inquirer.prompt(questions_2)
+                    param_dict['jobbergate_config'].update(test_answers)
             param_filename = '/tmp/param_dict.json'
             param_file =  open(param_filename, 'w')
             json.dump(param_dict, param_file)

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -131,7 +131,7 @@ class JobbergateApi:
         return response
 
     @tabulate_decorator
-    def create_job_script(self, job_script_name, application_id, param_file):
+    def create_job_script(self, job_script_name, application_id, param_file, debug):
         data = self.job_script_config
         data['job_script_name'] = job_script_name
         data['application'] = application_id
@@ -245,6 +245,10 @@ class JobbergateApi:
                 job_script_data_as_string += value
 
             response['job_script_data_as_string'] = job_script_data_as_string
+
+        if debug == False:
+            print("no debug.. dropping job_script_data_as_string")
+            response = [{k: v for k, v in d.items() if k == "job_script_data_as_string"} for d in response]
 
         return response
 
@@ -412,7 +416,8 @@ class JobbergateApi:
             files=files
         )
 
-        response = [{k: v for k, v in d.items() if k not in self.application_suppress} for d in response]
+        for key in self.application_suppress:
+            response.pop(key, None)
         os.remove(tar_name)
         return response
 

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -115,7 +115,8 @@ class JobbergateApi:
             method="GET",
             endpoint=f"{self.api_endpoint}/job-script/"
         )
-        response = [{k: v for k, v in d.items() if k != 'job_script_data_as_string'} for d in response]
+        suppress = ['created_at', 'updated_at', 'job_script_data_as_string']
+        response = [{k: v for k, v in d.items() if k not in suppress} for d in response]
         return response
 
     @tabulate_decorator
@@ -282,6 +283,8 @@ class JobbergateApi:
             method="GET",
             endpoint=f"{self.api_endpoint}/job-submission/"
         )
+        suppress = ['created_at', 'updated_at']
+        response = [{k: v for k, v in d.items() if k not in suppress} for d in response]
         return response
 
     @tabulate_decorator

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -171,7 +171,6 @@ class JobbergateApi:
             application = module.JobbergateApplication(param_dict)
 
             for i in range(len(application._questions)):
-                print(application._questions[i].__class__.__name__)
                 if application._questions[i].__class__.__name__ == 'List':
                     question = inquirer.List(
                                     name=application._questions[i].variablename,
@@ -209,9 +208,7 @@ class JobbergateApi:
                         message=shared_questions[i].message,)
                 questions_2.append(question)
             test_answers = inquirer.prompt(questions_2)
-            print("param_dict with test_answers:")
             param_dict['jobbergate_config'].update(test_answers)
-            print(param_dict)
             param_filename = '/tmp/param_dict.json'
             param_file =  open(param_filename, 'w')
             json.dump(param_dict, param_file)
@@ -219,7 +216,6 @@ class JobbergateApi:
 
             #TODO: Put below in function after testing - DRY
             files = {'upload_file': open(param_filename, 'rb')}
-            print(param_dict)
 
             response = self.jobbergate_request(
                 method="POST",
@@ -372,7 +368,7 @@ class JobbergateApi:
             method="GET",
             endpoint=f"{self.api_endpoint}/application/"
         )
-        response = [{k: v for k, v in d.items() if k != 'application_file'} for d in response]
+        response = [{k: v for k, v in d.items() if k not in ['application_config', 'application_file']} for d in response]
         return response
 
     @tabulate_decorator

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -65,13 +65,6 @@ class JobbergateApi:
                     verify=False).json()
             except Exception as e:
                 print(e)
-                response = requests.post(
-                    endpoint,
-                    data=data,
-                    files=files,
-                    headers={'Authorization': 'JWT ' + self.token},
-                    verify=False)
-                print(response.text)
         return response
 
     def jobbergate_run(self, application_name, *argv):

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -148,7 +148,6 @@ class JobbergateApi:
                 files=files
             )
 
-            print(response)
             rendered_dict = json.loads(response['job_script_data_as_string'])
 
             job_script_data_as_string = ""
@@ -205,7 +204,6 @@ class JobbergateApi:
                 questions_2 = []
                 for i in range(len(shared_questions)):
                     if shared_questions[i].default:
-                        print(shared_questions[i].variablename)
                         question = inquirer.Text(
                             name=shared_questions[i].variablename,
                             message=shared_questions[i].message,
@@ -247,8 +245,7 @@ class JobbergateApi:
             response['job_script_data_as_string'] = job_script_data_as_string
 
         if debug == False:
-            print("no debug.. dropping job_script_data_as_string")
-            response = [{k: v for k, v in d.items() if k == "job_script_data_as_string"} for d in response]
+            del response['job_script_data_as_string']
 
         return response
 

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -71,7 +71,7 @@ class JobbergateApi:
                     files=files,
                     headers={'Authorization': 'JWT ' + self.token},
                     verify=False)
-                print(response.content)
+                print(response.text)
         return response
 
     def jobbergate_run(self, application_name, *argv):

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -246,8 +246,9 @@ class JobbergateApi:
                 shared_questions = application.shared(
                     data=param_dict['jobbergate_config']
                 )
-                # questions_2 awful name - pick a new one
+
                 questions_2 = []
+
                 questions_shared = self.assemble_questions(
                     questions=shared_questions,
                     question_list=questions_2

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -137,7 +137,7 @@ class JobbergateApi:
                 files=files
             )
 
-            print(type(response['job_script_data_as_string']))
+            print(response)
             rendered_dict = json.loads(response['job_script_data_as_string'])
 
             job_script_data_as_string = ""

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -153,7 +153,6 @@ class JobbergateApi:
                 endpoint=f"{self.api_endpoint}/application/{application_id}"
             )
 
-            # config = yaml.safe_load(app_data['application_file'])
             # param_dict = {
             #     "jobbergate_config": {},
             #     "application_config":{}
@@ -171,26 +170,57 @@ class JobbergateApi:
             # for key, value in config.items():
             #     for key2, value2 in value.items():
             #         param_dict[key][key2] = answers[key2]
+
+            # MODULE_PATH.write_text(app_data['application_file'])
+            # application_file.write_text(app_data['application_file'])
             application_file = open(MODULE_PATH, "w")
             w = application_file.write(app_data['application_file'])
             application_file.close()
 
-            application_config = open(CONFIG_PATH, "w")
-            w = application_config.write(app_data['application_config'])
-            application_config.close()
+            # CONFIG_PATH.write_text(app_data['application_config'])
+            # application_config.write(app_data['application_file'])
+            # application_config = open(CONFIG_PATH, "w")
+            # w = application_config.write(app_data['application_config'])
+            # application_config.close()
 
+            jobbergate_yaml_file = open(CONFIG_PATH)
+            jobbergate_yaml = yaml.load(jobbergate_yaml_file, Loader=yaml.FullLoader)
             module = self.import_questions_into_jobbergate_cli(module_path=MODULE_PATH)
-            print(dir(module))
-            module.JobbergateApplication.mainflow(self)
-            print(param_dict)
+            print(dir(module.JobbergateApplication(jobbergate_yaml)))
+            print(var_does_not_exist)
+            questions = []
+            config = yaml.safe_load(app_data['application_config'])
+            for i in range(len(self._questions)):
+                if hasattr(self._questions[i], "choices"):
+                    question = inquirer.List(
+                                    name=self._questions[i].variablename,
+                                    message=self._questions[i].message,
+                                    choices=self._questions[i].choices,)
+                else:
+                    question = inquirer.Text(
+                        name=self._questions[i].variablename,
+                        message=self._questions[i].message,)
+                questions.append(question)
 
-            param_filename = 'param_dict.json'
+            print(questions)
+            answers = inquirer.prompt(questions)
+            param_dict = {
+                "jobbergate_config": {},
+                "application_config":{}
+                          }
+            print(config)
+            for key, value in config.items():
+                for key2, value2 in value.items():
+                    param_dict[key][key2] = answers[key2]
+            param_filename = '/tmp/param_dict.json'
             param_file =  open(param_filename, 'w')
             json.dump(param_dict, param_file)
             param_file.close()
 
             #TODO: Put below in function after testing - DRY
             files = {'upload_file': open(param_filename, 'rb')}
+            print(param_dict)
+            print(var_does_not_exist)
 
             response = self.jobbergate_request(
                 method="POST",

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -360,7 +360,7 @@ class JobbergateApi:
             data=data,
             files=files
         )
-        # del response['application_file']
+        del response['application_file']
         return response
 
     @tabulate_decorator

--- a/jobbergate_cli/jobbergate_common.py
+++ b/jobbergate_cli/jobbergate_common.py
@@ -41,3 +41,9 @@ JOB_SUBMISSION_CONFIG = {
     "job_submission_owner": "",
     "job_script": ""
 }
+
+MODULE_PATH = "/tmp/application.py"
+
+CONFIG_PATH = "/tmp/jobbergate.yaml"
+
+MODULE_NAME = ""

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -251,8 +251,7 @@ def list_job_submissions(ctx):
 @click.option("--id",
               "-i",
               "create_job_submission_job_script_id")
-@click.option("--render-only",
-              "-ro"
+@click.option("--dry-run",
               "render_only")
 @click.pass_obj
 def create_job_submission(ctx, create_job_submission_name, create_job_submission_job_script_id, render_only=None):

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -201,7 +201,7 @@ def list_job_scripts(ctx):
               "param_file",
               type=click.Path(),)
 @click.pass_obj
-def create_job_script(ctx, create_job_script_name, create_job_script_application_id, param_file):
+def create_job_script(ctx, create_job_script_name, create_job_script_application_id, param_file=None):
     resp = ctx.api.create_job_script(create_job_script_name, create_job_script_application_id, param_file)
     sys.stdout.write(str(resp))
     sys.exit(0)
@@ -251,9 +251,12 @@ def list_job_submissions(ctx):
 @click.option("--id",
               "-i",
               "create_job_submission_job_script_id")
+@click.option("--render-only",
+              "-ro"
+              "render_only")
 @click.pass_obj
-def create_job_submission(ctx, create_job_submission_name, create_job_submission_job_script_id):
-    resp = ctx.api.create_job_submission(create_job_submission_name, create_job_submission_job_script_id)
+def create_job_submission(ctx, create_job_submission_name, create_job_submission_job_script_id, render_only=None):
+    resp = ctx.api.create_job_submission(create_job_submission_name, create_job_submission_job_script_id, render_only)
     sys.stdout.write(str(resp))
     sys.exit(0)
 

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -200,9 +200,12 @@ def list_job_scripts(ctx):
               "-p",
               "param_file",
               type=click.Path(),)
+@click.option("--debug",
+              "debug",
+              default=False)
 @click.pass_obj
-def create_job_script(ctx, create_job_script_name, create_job_script_application_id, param_file=None):
-    resp = ctx.api.create_job_script(create_job_script_name, create_job_script_application_id, param_file)
+def create_job_script(ctx, create_job_script_name, create_job_script_application_id, debug, param_file=None):
+    resp = ctx.api.create_job_script(create_job_script_name, create_job_script_application_id, param_file, debug)
     sys.stdout.write(str(resp))
     sys.exit(0)
 

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import getpass
 import requests
 import sys
@@ -11,9 +10,11 @@ import click
 from datetime import datetime
 
 from jobbergate_cli.jobbergate_api_wrapper import JobbergateApi
-from jobbergate_cli.jobbergate_common import JOBBERGATE_API_JWT_PATH, JOBBERGATE_API_ENDPOINT, \
-    JOBBERGATE_API_OBTAIN_TOKEN_ENDPOINT, JOBBERGATE_APPLICATION_BASE_PATH, \
-    APPLICATION_CONFIG, JOB_SCRIPT_CONFIG, JOB_SUBMISSION_CONFIG, JOBBERGATE_USER_TOKEN_DIR
+from jobbergate_cli.jobbergate_common import JOBBERGATE_API_JWT_PATH, \
+    JOBBERGATE_API_ENDPOINT, JOBBERGATE_API_OBTAIN_TOKEN_ENDPOINT, \
+    JOBBERGATE_APPLICATION_BASE_PATH, APPLICATION_CONFIG, JOB_SCRIPT_CONFIG, \
+    JOB_SUBMISSION_CONFIG, JOBBERGATE_USER_TOKEN_DIR
+
 
 class Api(object):
     def __init__(self, user_id=None):
@@ -24,6 +25,7 @@ class Api(object):
             application_config=APPLICATION_CONFIG,
             api_endpoint=JOBBERGATE_API_ENDPOINT,
             user_id=user_id)
+
 
 def interactive_get_username_password():
     username = input("Please enter your username: ")
@@ -55,6 +57,7 @@ def is_token_valid():
     else:
         return False
 
+
 def decode_token_to_dict(encoded_token):
     try:
         token = jwt.decode(
@@ -66,6 +69,7 @@ def decode_token_to_dict(encoded_token):
         sys.exit()
     return token
 
+
 def init_api(user_id):
     api = JobbergateApi(
         token=JOBBERGATE_API_JWT_PATH.read_text(),
@@ -76,12 +80,14 @@ def init_api(user_id):
         user_id=user_id)
     return api
 
+
 def load_config():
     pass
 
 # Get the cli input arguments
 # args = get_parsed_args(argv)
-# Grab the pre-existing token, if doesn't exist or is invalid then grab a new one.
+# Grab the pre-existing token, if doesn't exist
+# or is invalid then grab a new one.
 #
 # Allow the user to pass their jobbergate username and password as command line
 # arguments. If a token isn't found or invalid AND the username and password
@@ -89,10 +95,11 @@ def load_config():
 # acquire the username password.
 
 
-
 # def get_parsed_args(argv):
 """Create argument parser and return cli args.
 """
+
+
 # Get the cli input arguments
 @click.group()
 @click.option(
@@ -106,10 +113,13 @@ def load_config():
     hide_input=True
 )
 @click.pass_context
-def main(ctx, username, password):
+def main(ctx,
+         username,
+         password):
     """
     ctx --> context
-    @click.pass_context makes username, password, token and user_id available to the other cmd
+    @click.pass_context makes username, password,
+    token and user_id available to the other cmd
     """
     ctx.ensure_object(dict)
 
@@ -125,9 +135,11 @@ def main(ctx, username, password):
             ctx.obj['username'] = username
             ctx.obj['password'] = password
         init_token(username, password)
-    ctx.obj['token'] = decode_token_to_dict(JOBBERGATE_API_JWT_PATH.read_text())
+    ctx.obj['token'] = decode_token_to_dict(
+        JOBBERGATE_API_JWT_PATH.read_text())
 
     ctx.obj = Api(user_id=ctx.obj['token']['user_id'])
+
 
 @main.command('list-applications')
 @click.pass_obj
@@ -135,6 +147,7 @@ def list_applications(ctx):
     resp = ctx.api.list_applications()
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('create-application')
 @click.option("--name",
@@ -144,7 +157,9 @@ def list_applications(ctx):
               "-a",
               "create_application_path")
 @click.pass_obj
-def create_application(ctx, create_application_name, create_application_path):
+def create_application(ctx,
+                       create_application_name,
+                       create_application_path):
     resp = ctx.api.create_application(
         application_name=create_application_name,
         application_path=create_application_path,
@@ -152,35 +167,42 @@ def create_application(ctx, create_application_name, create_application_path):
     sys.stdout.write(str(resp))
     sys.exit(0)
 
+
 @main.command('get-application')
 @click.option("--id",
               "-i",
               "get_application_id")
 @click.pass_obj
-def get_application(ctx, get_application_id):
+def get_application(ctx,
+                    get_application_id):
     resp = ctx.api.get_application(get_application_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('update-application')
 @click.option("--id",
               "-i",
               "update_application_id")
 @click.pass_obj
-def update_application(ctx, update_application_id):
+def update_application(ctx,
+                       update_application_id):
     resp = ctx.api.update_application(update_application_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('delete-application')
 @click.option("--id",
               "-i",
               "delete_application_id")
 @click.pass_obj
-def delete_application(ctx, delete_application_id):
+def delete_application(ctx,
+                       delete_application_id):
     resp = ctx.api.delete_application(delete_application_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('list-job-scripts')
 @click.pass_obj
@@ -188,6 +210,7 @@ def list_job_scripts(ctx):
     resp = ctx.api.list_job_scripts()
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('create-job-script')
 @click.option("--name",
@@ -204,8 +227,16 @@ def list_job_scripts(ctx):
               "debug",
               default=False)
 @click.pass_obj
-def create_job_script(ctx, create_job_script_name, create_job_script_application_id, debug, param_file=None):
-    resp = ctx.api.create_job_script(create_job_script_name, create_job_script_application_id, param_file, debug)
+def create_job_script(ctx,
+                      create_job_script_name,
+                      create_job_script_application_id,
+                      debug,
+                      param_file=None):
+    resp = ctx.api.create_job_script(
+        create_job_script_name,
+        create_job_script_application_id,
+        param_file,
+        debug)
     sys.stdout.write(str(resp))
     sys.exit(0)
 
@@ -215,30 +246,36 @@ def create_job_script(ctx, create_job_script_name, create_job_script_application
               "-i",
               "get_job_script_id")
 @click.pass_obj
-def get_job_script(ctx, get_job_script_id):
+def get_job_script(ctx,
+                   get_job_script_id):
     resp = ctx.api.get_job_script(get_job_script_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('update-job-script')
 @click.option("--id",
               "-i",
               "update_job_script_id")
 @click.pass_obj
-def update_job_script(ctx, update_job_script_id):
+def update_job_script(ctx,
+                      update_job_script_id):
     resp = ctx.api.update_job_script(update_job_script_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('delete-job-script')
 @click.option("--id",
               "-i",
               "delete_job_script_id")
 @click.pass_obj
-def delete_job_script(ctx, delete_job_script_id):
+def delete_job_script(ctx,
+                      delete_job_script_id):
     resp = ctx.api.delete_job_script(delete_job_script_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('list-job-submissions')
 @click.pass_obj
@@ -246,6 +283,7 @@ def list_job_submissions(ctx):
     resp = ctx.api.list_job_submissions()
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('create-job-submission')
 @click.option("--name",
@@ -257,8 +295,14 @@ def list_job_submissions(ctx):
 @click.option("--dry-run",
               "render_only")
 @click.pass_obj
-def create_job_submission(ctx, create_job_submission_name, create_job_submission_job_script_id, render_only=None):
-    resp = ctx.api.create_job_submission(create_job_submission_name, create_job_submission_job_script_id, render_only)
+def create_job_submission(ctx,
+                          create_job_submission_name,
+                          create_job_submission_job_script_id,
+                          render_only=None):
+    resp = ctx.api.create_job_submission(
+        create_job_submission_name,
+        create_job_submission_job_script_id,
+        render_only)
     sys.stdout.write(str(resp))
     sys.exit(0)
 
@@ -268,30 +312,36 @@ def create_job_submission(ctx, create_job_submission_name, create_job_submission
               "-i",
               "get_job_submission_id")
 @click.pass_obj
-def get_job_submission(ctx, get_job_submission_id):
+def get_job_submission(ctx,
+                       get_job_submission_id):
     resp = ctx.api.get_job_submission(get_job_submission_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('update-job-submission')
 @click.option("--id",
               "-i",
               "update_job_submission_id")
 @click.pass_obj
-def update_job_submission(ctx, update_job_submission_id):
+def update_job_submission(ctx,
+                          update_job_submission_id):
     resp = ctx.api.update_job_submission(update_job_submission_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 @main.command('delete-job-submission')
 @click.option("--id",
               "-i",
               "delete_job_submission_id")
 @click.pass_obj
-def delete_job_submission(ctx, delete_job_submission_id):
+def delete_job_submission(ctx,
+                          delete_job_submission_id):
     resp = ctx.api.delete_job_submission(delete_job_submission_id)
     sys.stdout.write(str(resp))
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/jobbergate_cli/workflow.py
+++ b/jobbergate_cli/workflow.py
@@ -1,0 +1,73 @@
+"""
+Workflow
+========
+
+Work flow module that could add pre and post functions to workflows"""
+
+from functools import partial, wraps
+
+prefuncs = {}
+postfuncs = {}
+
+
+def logic(func=None, *, name=None, prepost=None):
+    """A decorator that registers functions as either pre or post to workflows.
+
+    :param name: (optional) Descriptive name that is used when choosing workflow
+
+
+    Hooking a pre-function to eigen implicit by function name:
+
+    .. code-block:: python
+
+        # Hooking pre function to `eigen` implicit by function name
+        @logic
+        def pre_eigen(data):
+            print("Pre function to `eigen` questions")
+
+
+    Explicit hooking post function to `eigen` workflow:
+
+    .. code-block:: python
+
+        @logic(name="eigen", prepost="post")
+        def myfunction(data):
+            print("Post function to `eigen` questions")
+
+    Pre and post that are run before and after all questions, respectively:
+
+    .. code-block:: python
+
+        @logic
+        def pre_(data):
+            print("Pre function that runs before any question")
+
+        @logic()
+        def post_(data):
+            print("Post function that is run after all questions")
+    """
+    if func is None:
+        return partial(logic, name=name, prepost=prepost)
+
+    @wraps(func)
+    def wrapper(*args, **kvargs):
+        return func(*args, **kvargs)
+
+    if name is None:
+        if func.__name__.startswith("pre_"):
+            name = func.__name__[4:]
+            prepost = "pre"
+
+        if func.__name__.startswith("post_"):
+            name = func.__name__[5:]
+            prepost = "post"
+
+    if prepost == "pre":
+        prefuncs[name] = func
+        return wrapper
+
+    if prepost == "post":
+        postfuncs[name] = func
+        return wrapper
+
+    raise NameError

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,3 +4,4 @@ click
 boto3
 tabulate
 jinja2
+pyyaml

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,6 @@
 requests
 pyjwt
 click
-boto3
 tabulate
 jinja2
 pyyaml

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,3 +5,4 @@ boto3
 tabulate
 jinja2
 pyyaml
+inquirer

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
-
-x]
+[tox]
 skipsdist = True
 envlist = unit, functional
 skip_missing_interpreters = True
+
 [testenv]
 basepython = python3
 setenv =
   PYTHONPATH = {toxinidir}/lib/:{toxinidir}
 passenv = HOME
+
 [testenv:unit]
 commands =
     coverage run -m unittest discover -s {toxinidir}/tests/unit -v
@@ -16,10 +17,12 @@ commands =
     coverage html \
 	--omit tests/*,mod/*,.tox/*
 deps = -r{toxinidir}/tests/unit/requirements.txt
+
 [testenv:functional]
 changedir = {toxinidir}/tests/functional
 commands = functest-run-suite {posargs}
 deps = -r{toxinidir}/tests/functional/requirements.txt
+
 [testenv:lint]
 commands = flake8 {posargs} jobbergate_cli/
 deps =
@@ -28,6 +31,7 @@ deps =
     flake8-import-order
     pep8-naming
     flake8-colors
+
 [flake8]
 exclude =
     .git,
@@ -37,5 +41,6 @@ exclude =
 max-line-length = 79
 max-complexity = 10
 import-order-style = edited
+
 [isort]
 force_to_top=setuppath


### PR DESCRIPTION
### Purpose:

jobbergate-cli needs to work with the starccm app adapted from original scania app: https://github.com/omnivector-solutions/jobbergate-hello-world-application/tree/lgcy_starccm/lgcy_starccm

### Changes:
* accepts application.py (adaptation of the original views.py) back from API and uses that to drive questions
* use with application.py:
    - support for mainflow() on init
    - uses answers from mainflow() to assemble questions in shared() - if present or skips if application.py does not use shared() `if hasattr(application, "shared"):`
    - delivers core functionality of executing questions dynamically so answer to one question determines options/path for other questions
* assemble_questions() is single function that accepts questions from application.py and assembles them to a list of questions for inquirer library to execute with inquirer.prompt()
* cleanup output for list-* and create-*
    - user does not need to view create/update timestamps and application dir fields
* hide job_script_data_as_str field behind --debug so only displays if user passes `--debug True`
* cleanup create-application so tar file is not left on users local fs
* cleanup output of list-job-submissions - user does not need to review timestamps
* brought in appform.py from lgcy for use with constructing questions - minimizes changes needed to legacy apps like starccm