### PR TITLE
Autosubmit

### DIFF
--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -458,8 +458,9 @@ class JobbergateApi:
         if 'job_script_data_as_string' in response:
             filename = f'{data["job_script_name"]}.job'
             print(f'Creating job script file: {filename}')
+            scriptstring = json.loads(response['job_script_data_as_string'])["application.sh"]
             with open(filename, 'w') as fh:
-                fh.write(response['job_script_data_as_string'])
+                fh.write(scriptstring)
 
         job_script_data_as_string = ""
         for key, value in rendered_dict.items():

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -411,6 +411,13 @@ class JobbergateApi:
             except:
                 print(response)
 
+            # Write local copy of script
+            if 'job_script_data_as_string' in response:
+                filename = f'{data["job_script_name"]}.job'
+                print(f'Creating job script file: {filename}')
+                with open(filename, 'w') as fh:
+                    fh.write(response['job_script_data_as_string'])
+
             job_script_data_as_string = ""
             for key, value in rendered_dict.items():
                 job_script_data_as_string += "\n\nNEW_FILE\n\n"
@@ -424,7 +431,7 @@ class JobbergateApi:
         # Check if user wants to submit immediately
         submit = inquirer.prompt([inquirer.Confirm('sub', message='Would you like to submit this immediately?', default=True)])['sub']
         if submit:
-            response["submission_result"] = self.create_job_submission(response['id'], False, response['job_script_name'])
+            response['submission_result'] = self.create_job_submission(response['id'], False, response['job_script_name'])
 
         return response
 

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -421,6 +421,11 @@ class JobbergateApi:
         if debug is False:
             del response['job_script_data_as_string']
 
+        # Check if user wants to submit immediately
+        submit = inquirer.prompt([inquirer.Confirm('sub', message='Would you like to submit this immediately?', default=True)])['sub']
+        if submit:
+            response["submission_result"] = self.create_job_submission(response['id'], False, response['job_script_name'])
+
         return response
 
     @tabulate_decorator

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -376,6 +376,10 @@ class JobbergateApi:
             # TODO: Put below in function after testing - DRY
             files = {'upload_file': open(param_filename, 'rb')}
 
+            # Possibly overwrite script name
+            if 'job_script_name' in param_dict['jobbergate_config']:
+                data['job_script_name'] = param_dict['jobbergate_config']['job_script_name']
+
         response = self.jobbergate_request(
             method="POST",
             endpoint=f"{self.api_endpoint}/job-script/",

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -458,9 +458,10 @@ class JobbergateApi:
         if 'job_script_data_as_string' in response:
             filename = f'{data["job_script_name"]}.job'
             print(f'Creating job script file: {filename}')
-            scriptstring = json.loads(response['job_script_data_as_string'])["application.sh"]
-            with open(filename, 'w') as fh:
-                fh.write(scriptstring)
+            scriptdict = json.loads(response['job_script_data_as_string'])
+            if 'application.sh' in scriptdict.keys():
+                with open(filename, 'w') as fh:
+                    fh.write(scriptdict['application.sh'])
 
         job_script_data_as_string = ""
         for key, value in rendered_dict.items():

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -243,7 +243,8 @@ def list_job_scripts(ctx, all=False):
 @main.command('create-job-script')
 @click.option("--name",
               "-n",
-              "create_job_script_name")
+              "create_job_script_name",
+              default="default_script_name")
 @click.option("--application-id",
               "-i",
               "create_job_script_application_id")


### PR DESCRIPTION
create-job-script:
- Now saves a local copy when making scripts (may need to be adjusted depending on formatting of the response's _job_script_data_as_string_ field.

- No longer requires name to be defined, defaulting to "default_script_name" ... you might want to change that one. 
Can also be overwritten in the script creation process, if "job_script_name" is defined through an app's question or such. 

- Now asks user if they want to immediately submit the script.

- (removed some code duplication in treatment of parameter file/no parameter file)