### PR TITLE
Nextworkflow chain

### DIFF
--- a/jobbergate_cli/application_base.py
+++ b/jobbergate_cli/application_base.py
@@ -8,12 +8,12 @@ class JobbergateApplicationBase:
 
     def __init__(self, jobbergate_yaml):
         """Initialize class attributes."""
-        self._questions = []
+        # self._questions = []
         self.jobbergate_config = jobbergate_yaml['jobbergate_config']
         self.application_config = jobbergate_yaml['application_config']
-        self.mainflow()
+        # self.mainflow()
 
-    def mainflow(self):
+    def mainflow(self, data):
         """Implements the main question asking workflow."""
         raise Exception("Inheriting class must override this method.")
 

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -368,14 +368,8 @@ class JobbergateApi:
             module = self.import_jobbergate_application_module_into_jobbergate_cli()
             application = module.JobbergateApplication(param_dict)
 
-            # Begin question assembly
-            question_list = []
-            question_list = self.assemble_questions(
-                questions=application._questions,
-                question_list=question_list
-            )
-            answers = inquirer.prompt(question_list)
-            param_dict['jobbergate_config'].update(answers)
+            # Begin question assembly, starting in "mainflow" method
+            param_dict['jobbergate_config']['nextworkflow'] = "mainflow"
 
             while "nextworkflow" in param_dict['jobbergate_config']:
                 method_to_call = getattr(application, param_dict['jobbergate_config'].pop("nextworkflow")) # Use and remove from the dict

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -377,8 +377,10 @@ class JobbergateApi:
             answers = inquirer.prompt(question_list)
             param_dict['jobbergate_config'].update(answers)
 
-            if hasattr(application, "shared"):
-                shared_questions = application.shared(
+            while "nextworkflow" in param_dict['jobbergate_config']:
+                method_to_call = getattr(application, param_dict['jobbergate_config'].pop("nextworkflow")) # Use and remove from the dict
+
+                shared_questions = method_to_call(
                     data=param_dict['jobbergate_config']
                 )
 


### PR DESCRIPTION
create-job-script:

- Adds ability for applications to chain methods together, enabling many-step processing. This is done by defining "nextworkflow" in every method of the application meant to have a successor. Still hardcoded to start with "mainflow" method. 

- Now treating the first method (mainflow) the same as the other ones. Sending in a dictionary and expecting a list of questions in return. Application base no longer needs the self._questions list.

Example application using this is available in ID 84  "chain2", chaining through 3 methods with differing paths.
```
    mainflow <--- START
    /      \
Sim         Mesh
    \       /
      wrapup   
```