### PR TITLE
Error handling for empty password field.

### DIFF
--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -151,6 +151,9 @@ def main(ctx, username, password):
         except KeyError:
             print(f"Auth Failed for username: {username}, please try again")
             sys.exit(0)  # FIXME - ctx.exit() instead
+        except TypeError:
+            print("Password cannot be empty, please try again")
+            sys.exit(0)  # FIXME - ctx.exit() instead
         except requests.exceptions.ConnectionError:
             print("Auth failed to establish connection with API, please try again")
             sys.exit(0)  # FIXME - ctx.exit() instead


### PR DESCRIPTION
If we want to be more specific and not catch all TypeErrors, we could check for empty PW earlier, after line 146: 
username, password = interactive_get_username_password()