### PR TITLE
Fix for BooleanList questions

### DIFF
--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -549,7 +549,10 @@ class JobbergateApi:
                 else:
                     # Prepare question for user
                     question = self.assemble_questions(field)
-                    questions.append(question)
+                    if isinstance(question, list):
+                        questions.extend(question)
+                    else:
+                        questions.append(question)
 
             workflow_answers = inquirer.prompt(questions, raise_keyboard_interrupt=True)
             workflow_answers.update(auto_answers)


### PR DESCRIPTION
assemble_questions function can return either an Inquirer question or a list of them. 

Alternatively we could have the function always return a list, and always use list.extend instead of list.append.