### PR TITLE
Add release prep/automation to jobbergate-cli

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,16 @@
+minVersion: "0.12.0"
+github:
+  owner: corydodt
+  repo: jobbergate-cli
+releaseBranchPrefix: release
+changelog: CHANGELOG.md
+changelogPolicy: auto
+statusProvider:
+  name: github
+  config:
+    contexts:
+      - "ReleaseAction"
+artifactProvider:
+  name: github
+targets:
+  - name: github

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,6 @@
 minVersion: "0.12.0"
 github:
-  owner: corydodt
+  owner: omnivector-solutions
   repo: jobbergate-cli
 releaseBranchPrefix: release
 changelog: CHANGELOG.md

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -65,7 +65,6 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=release_version::$(echo $(git branch | grep '*' | awk '{print $2}') | sed 's/[a-z-]*\///g')"
           echo "::set-output name=snap_file::$(ls *.snap)"
           echo "::set-output name=git_sha::$(git rev-parse HEAD)"
 

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -1,0 +1,96 @@
+name: 'PrepareRelease'
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (optional)
+        required: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    name: "Run craft prepare"
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: set-env
+        run: |
+          echo 'RELEASE_VERSION=${{ github.event.inputs.version }}' >> $GITHUB_ENV;
+          echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV;
+
+      - id: set-git-user
+        run: |
+          git config user.name omnivector-qa
+          git config user.email admin@omnivector.solutions
+
+      - uses: getsentry/craft@master
+        name: "Craft Prepare"
+        with:
+          action: prepare
+          version: ${{ env.RELEASE_VERSION }}
+        env:
+          GIT_COMMITTER_NAME: omnivector-qa
+          GIT_AUTHOR_NAME: omnivector-qa
+          EMAIL: admin@omnivector.solutions
+
+  build:
+    runs-on: ubuntu-latest
+    name: "Build artifacts for the release"
+    needs: [prepare]
+    steps:
+      - id: set-version
+        run: |
+          echo 'RELEASE_VERSION=${{ github.event.inputs.version }}' >> $GITHUB_ENV;
+          echo 'RELEASE_PREFIX=jobbergate-cli-${{ github.event.inputs.version }}' >> $GITHUB_ENV;
+
+      - uses: actions/checkout@v2
+        with:
+          ref: release/${{ env.RELEASE_VERSION }}
+
+      - id: set-git-user
+        run: |
+          git config user.name omnivector-qa
+          git config user.email admin@omnivector.solutions
+
+      - name: "Install Snapcraft"
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          use_lxd: true
+
+      - name: "Build snap"
+        run: make snap
+
+      - name: "Parse and store git_sha, release_version"
+        if: ${{ success() }}
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-output name=release_version::$(echo $(git branch | grep '*' | awk '{print $2}') | sed 's/[a-z-]*\///g')"
+          echo "::set-output name=snap_file::$(ls *.snap)"
+          echo "::set-output name=git_sha::$(git rev-parse HEAD)"
+
+      - name: Archive Artifacts
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.vars.outputs.git_sha }}
+          path: |
+            ${{ steps.vars.outputs.snap_file }}
+
+      - uses: Sibz/github-status-action@v1
+        if: ${{ success() }}
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'ReleaseAction'
+          description: 'Passed'
+          state: 'success'
+          sha: ${{ steps.vars.outputs.git_sha }}
+
+##      - uses: 8398a7/action-slack@v3
+##        with:
+##          status: ${{ job.status }}
+##          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+##        env:
+##          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+##        if: always() # Pick up events even if the job fails or is canceled.
+##

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,0 +1,55 @@
+name: 'PublishRelease'
+
+on:
+  workflow_dispatch:
+    inputs:
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    name: "Upload the artifact"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Parse and store the release_version"
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-output name=release_version::$(echo $(git branch | grep '*' | awk '{print$2}') | sed 's/[a-z-]*\///g')"
+
+      - id: set-env
+        if: ${{ success() }}
+        run: |
+          echo 'RELEASE_VERSION=${{ steps.vars.outputs.release_version }}' >> $GITHUB_ENV;
+
+      - id: set-git-user
+        run: |
+          git config user.name omnivector-qa
+          git config user.email admin@omnivector.solutions
+
+      - uses: getsentry/craft@master
+        if: ${{ success() }}
+        name: "Craft Publish"
+        with:
+          action: publish
+          version: ${{ env.RELEASE_VERSION }}
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CRAFT_LOG_LEVEL: debug
+
+      - id: next-dev-version
+        if: ${{ success() }}
+        run: |
+          git fetch --all
+          git checkout master
+          ./scripts/bump-version.sh '' "${RELEASE_VERSION}+dev"
+          git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull --rebase && git push
+
+##       - uses: 8398a7/action-slack@v3
+##         with:
+##           status: ${{ job.status }}
+##           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+##         env:
+##           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+##         if: always() # Pick up events even if the job fails or is canceled.
+##

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ snap: $(SNAP_TARGET)
 
 
 $(SNAP_TARGET):
-	snapcraft --use-lxd
+	sg lxd -c 'snapcraft --use-lxd'

--- a/jobbergate_cli/jobbergate_common.py
+++ b/jobbergate_cli/jobbergate_common.py
@@ -16,9 +16,9 @@ JOBBERGATE_CACHE_DIR = os.environ.get(
     "JOBBERGATE_CACHE_DIR", Path.home() / ".jobbergate"
 )
 JOBBERGATE_API_ENDPOINT = os.environ.get(
-    "JOBBERGATE_API_ENDPOINT", "https://jobbergate-api-production.omnivector.solutions"
+    "JOBBERGATE_API_ENDPOINT", "https://jobbergate-api.omnivector.solutions"
 )
-# for reference: staging: "https://jobbergate-api-staging.omnivector.solutions"
+# for reference: staging: "https://jobbergate-api-staging-eu-north-1.omnivector.solutions"
 
 # enable http tracing, accepts e.g. "1", "true", "0", "false"
 JOBBERGATE_DEBUG = ConfigParser.BOOLEAN_STATES.get(

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -266,11 +266,7 @@ def list_job_scripts(ctx, all=False):
 @main.command("create-job-script")
 @click.option("--name", "-n", "create_job_script_name", default="default_script_name")
 @click.option("--application-id", "-i", "create_job_script_application_id")
-@click.option(
-    "--param-file",
-    "param_file",
-    type=click.Path()
-)
+@click.option("--param-file", "param_file", type=click.Path())
 @click.option("--fast", "-f", "fast", is_flag=True)
 @click.option("--debug", "debug", is_flag=True)
 @click.pass_obj

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="$1"
+NEW_VERSION="$2"
+
+sed -i -e "s/^__version__ = "'".*"'"\$/__version__ = "'"'"$NEW_VERSION"'"'"/" setup.py
+# TODO # sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
+
+echo "New version: $NEW_VERSION"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         # required for click.version_option()
         "importlib_metadata ; python_version < '3.8'",
         "inquirer",
-        "pyjwt",
+        "pyjwt<2",  # FIXME pyjwt >= 2 requires an algorithms argument that breaks tests
         "pyyaml",
         "requests",
         "tabulate",

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
 from setuptools import find_packages, setup
 
 
+__version__ = "0.0.1+dev"
+
 setup(
     name="jobbergate-cli",
     packages=find_packages(include=["jobbergate_cli", "jobbergate_cli.*"]),
-    version="0.0.1+dev",
+    version=__version__,
     license="MIT",
     long_description=open("README.md").read(),
     install_requires=[


### PR DESCRIPTION
Adds publish_release and prepare_release actions.

- Currently not working: "PublishRelease". craft hardcodes "master" as the name of the default branch, and this repo uses "main".
- Also modifies JOBBERGATE_API_ENDPOINT default.