### PR TITLE
Short description when listing apps

### DIFF
--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -930,6 +930,9 @@ class JobbergateApi:
 
         # Sort
         response.sort(key=lambda app: app["id"], reverse=True)
+        # Cap description length
+        for app in (app for app in response if len(app["application_description"])>75):
+            app["application_description"] = app["application_description"][:72]+"..."
 
         if all:
             return response

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -931,8 +931,8 @@ class JobbergateApi:
         # Sort
         response.sort(key=lambda app: app["id"], reverse=True)
         # Cap description length
-        for app in (app for app in response if len(app["application_description"])>75):
-            app["application_description"] = app["application_description"][:72]+"..."
+        for app in response:
+            app["application_description"] = _fit_line(app["application_description"])
 
         if all:
             return response
@@ -1092,3 +1092,27 @@ class JobbergateApi:
         )
 
         return response
+
+
+def _fit_line(s: str, n: int = 79):
+    """
+    Smartly ellipsize a line to fit in n (default 79) characters.
+
+    This method ensures only one line will be displayed, and an ellipsis is only used
+    if there are several characters to be hidden.
+    """
+    assert n >= 15
+    snip = n - 8
+
+    truncate = False
+    s = s.strip()
+    if "\n" in s:
+        truncate = True
+    s = s.split("\n")[0].strip()
+    if len(s) > n:
+        truncate = True
+
+    if truncate:
+        return s[:snip] + "..."
+
+    return s

--- a/jobbergate_cli/jobbergate_common.py
+++ b/jobbergate_cli/jobbergate_common.py
@@ -16,7 +16,8 @@ JOBBERGATE_CACHE_DIR = os.environ.get(
     "JOBBERGATE_CACHE_DIR", Path.home() / ".jobbergate"
 )
 JOBBERGATE_API_ENDPOINT = os.environ.get(
-    "JOBBERGATE_API_ENDPOINT", "https://jobbergate-api-prod-eu-north-1.omnivector.solutions"
+    "JOBBERGATE_API_ENDPOINT",
+    "https://jobbergate-api-prod-eu-north-1.omnivector.solutions",
 )
 # for reference: staging: "https://jobbergate-api-staging-eu-north-1.omnivector.solutions"
 

--- a/jobbergate_cli/test/test_jobbergate_api_wrapper.py
+++ b/jobbergate_cli/test/test_jobbergate_api_wrapper.py
@@ -1,0 +1,26 @@
+"""
+Tests of the API client architecture and related functions
+"""
+
+from pytest import mark
+
+from jobbergate_cli import jobbergate_api_wrapper
+
+
+@mark.parametrize(
+    "input,expected",
+    [
+        ["hello world", "hello world"],
+        ["\nhello world\n", "hello world"],
+        ["hello world\nhello world", "hello world..."],
+        ["hello world \nhello world", "hello world..."],
+        ["hello world how are you?", "hello world..."],
+        ["\nhello world how are you?\n2", "hello world..."],
+    ],
+    ids=["plain", "strip-ws", "short-nl", "short-nl-ws", "long", "long-nl"],
+)
+def test_fit_line(input, expected):
+    """
+    Do we truncate a string in the expected ways?
+    """
+    assert jobbergate_api_wrapper._fit_line(input, n=19) == expected


### PR DESCRIPTION
NOT TESTED, field name based on serializer in the jobbergate-cli repo.
Cause for the change: If even one application has a very long description, every single application takes several rows to display. For applications without descriptions, this means a lot of empty space.

Amount of characters could be debated. 
Full descriptions still available through get-application.