### PR TITLE
Armada-636 Update application functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+* Fixed requiring input for both username and password when one of them was already provided.
+* Fixed the descripition for the option --update-identifier for update-application.
+* Fixed application_id was not recovered at update-application when the user selected the application by its identifier.
+* Fixed application_file and application_config, because the columns were not updated in the back-end when updating the application.
 
 1.2.0 -- 2021-12-06
 -------------------

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -1167,6 +1167,7 @@ class JobbergateApi:
                     f"/application/?identifier={application_identifier}",
                 ),
             )
+            application_id = data["id"]
 
         if "error" in data.keys():
             return data

--- a/jobbergate_cli/jobbergate_api_wrapper.py
+++ b/jobbergate_cli/jobbergate_api_wrapper.py
@@ -484,7 +484,7 @@ class JobbergateApi:
 
         if not application_id and not application_identifier:
             response = self.error_handle(
-                error="--application-id and --aplication-identifier for the job script not defined",
+                error="--application-id and --application-identifier for the job script not defined",
                 solution="Please try again with one of them specified",
             )
             parameter_check.append(response)
@@ -1177,6 +1177,18 @@ class JobbergateApi:
         del data["updated_at"]
         if application_desc:
             data["application_description"] = application_desc
+
+        try:
+            with open(os.path.join(application_path, "jobbergate.py"), "r") as f:
+                data["application_file"] = f.read()
+            with open(os.path.join(application_path, "jobbergate.yaml"), "r") as f:
+                data["application_config"] = f.read()
+        except IOError:
+            response = self.error_handle(
+                error="Files jobbergate.py or jobbergate.yaml not found",
+                solution="Please verify if the files exist on the application path",
+            )
+            return response
 
         tar_list = [application_path, os.path.join(application_path, "templates")]
         self.tardir(application_path, TAR_NAME, tar_list)

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -54,8 +54,14 @@ APPLICATION_IDENTIFIER_EXPLANATION = """
 
     The identifier allows the user to access commonly used applications with a
     friendly name that is easy to remember. Identifiers should only be used
-    for applicaitons that are frequently used or should be easy to find in the list.
+    for applications that are frequently used or should be easy to find in the list.
     An identifier may be added, removed, or changed on an existing application.
+"""
+
+UPDATE_IDENTIFIER_EXPLANATION = """
+
+    Please, notice this option has priority when specified, and disables the
+    options --application-path and --application-desc.
 """
 
 
@@ -74,7 +80,7 @@ def init_cache_dir():
 
 def init_logs(username=None, verbose=False):
     """
-    Initialize the rotatating file log handler. Logs will be retained for 1 week.
+    Initialize the rotating file log handler. Logs will be retained for 1 week.
     """
     # Remove default stderr handler at level INFO
     logger.remove()
@@ -462,7 +468,10 @@ def get_application(ctx, id_, identifier):
     "-a",
     help="The path to the directory for updated application files",
 )
-@click.option("--update-identifier", help="The application identifier to be set")
+@click.option(
+    "--update-identifier",
+    help=f"The application identifier to be set. {UPDATE_IDENTIFIER_EXPLANATION}",
+)
 @click.option(
     "--application-desc",
     default="",


### PR DESCRIPTION
#### What

* Better describe the option `--update-identifier` for `update-application`;
* Fix `application_id` was not recovered at `update-application` when the user selected the application by its identifier;
* Fix `application_file` and `application_config`, because the columns were not updated in the back-end for  `update-application`.

#### Why
Improve user experience, as requested by [#120](https://github.com/omnivector-solutions/jobbergate/issues/120)

`Task`: https://app.clickup.com/t/18022949/ARMADA-636

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).