### PR TITLE
ASP-3106 clarification on wrong username

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,14 +5,19 @@ on: pull_request
 jobs:
   test:
     name: "Check quality"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry==1.4.2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-          architecture: 'x64'
-      - uses: Gr1N/setup-poetry@v7
+          python-version: "3.6"
+          architecture: "x64"
+          cache: "poetry"
+          cache-dependency-path: |
+            poetry.lock
+            pyproject.toml
       - name: "Run Tests"
         run: |
           make qa

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+* Improved error handling on login
 * Fixed requiring input for both username and password when one of them was already provided.
 * Fixed the descripition for the option --update-identifier for update-application.
 * Fixed application_id was not recovered at update-application when the user selected the application by its identifier.

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -132,7 +132,7 @@ def jobbergate_command_wrapper(func):
             message = f"Handling command '{ctx.command.name}'"
             if ctx.params:
                 message += " with params:"
-                for (key, value) in ctx.params.items():
+                for key, value in ctx.params.items():
                     message += f"\n  {key}={value}"
             logger.debug(message)
 
@@ -199,9 +199,15 @@ def init_token(username, password):
         JOBBERGATE_API_OBTAIN_TOKEN_ENDPOINT,
         data={"email": username, "password": password},
     )
+    if not resp.ok:
+        logger.error(f"Failed to retrieve a token, got response: {resp.text}")
+        resp.raise_for_status()
+
     data = resp.json()
-    ret = data.get("token")
-    JOBBERGATE_API_JWT_PATH.write_text(ret)
+    token = data.get("token")
+    if not token:
+        raise ValueError("No token found in response")
+    JOBBERGATE_API_JWT_PATH.write_text(token)
 
 
 def is_token_valid():


### PR DESCRIPTION
#### What
Improve error handling and logging when the login is done with invalid credentials.

#### Why
It was a request from the users, because the feedback was not very descriptive:
```python
jobbergate_cli.main:main:348 - Auth Failed for 'notanaddress@scania.com': data must be str, not NoneType
```

`Task`: https://jira.scania.com/browse/ASP-3106

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).