### PR TITLE
ASP-3781, ASP-3783 Add deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+* Added deprecation warning for jobbergate command
 
 1.2.1a0 -- 2023-07-11
 ---------------------

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -325,6 +325,12 @@ def main(ctx, username, password, verbose, raw, full):
     init_cache_dir()
     init_logs(username=username, verbose=verbose)
 
+    logger.warning(
+        "Deprecation Warning: Please consider migrating to new 'jobbergate', "
+        "since 'jobbergate-legacy' is planned to be decommissioned by week 7-2024.\n"
+        "Refer to https://github.com/omnivector-solutions/jobbergate to check out the new version."
+    )
+
     if SENTRY_DSN:
         logger.debug(f"Initializing Sentry with {SENTRY_DSN}")
         init_sentry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ profile = "black"
 
 [tool.poetry.scripts]
 jobbergate = "jobbergate_cli.main:main"
+jobbergate-legacy = "jobbergate_cli.main:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
* As a Jobbergate maintainer, I need to include a deprecation warning on jobbergate-legacy, so end-users are encouraged to transition to next-gen Jobbergate.
* Added entry-point `jobbergate-legacy`, so both versions can coexist once the alias `jobbergate` points to the new versions.

* https://jira.scania.com/browse/ASP-3781
* https://jira.scania.com/browse/ASP-3783