### PR TITLE
[ASP-4625] Enhance error report on jobbergate-legacy CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to jobbergate-cli
 
 Unreleased
 ----------
+* Added error traceback to the logs to help with debugging [ASP-4625]
 * Improved error handling on login
 * Fixed requiring input for both username and password when one of them was already provided.
 * Fixed the descripition for the option --update-identifier for update-application.

--- a/jobbergate_cli/main.py
+++ b/jobbergate_cli/main.py
@@ -156,6 +156,7 @@ def jobbergate_command_wrapper(func):
                 ),
             )
             logger.error(message)
+            logger.exception(err)
 
             # This allows us to capture exceptions here and still report them to sentry
             if SENTRY_DSN:


### PR DESCRIPTION
As a Jobbergate maintainer, I want its command line interface to provide better feedback to the users when it faces any error, so that troubleshooting and general user experience is improved.

No trace-back was provided to the users when the applications script faced any error at runtime, making it difficult to troubleshot and fix problems.